### PR TITLE
use cert-arn from validation to create dependency

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -16,7 +16,7 @@ output "domain_name" {
 }
 
 output "certificate_arn" {
-  value = join("", aws_acm_certificate.default.*.arn)
+  value = join("", aws_acm_certificate_validation.default.*.certificate_arn)
 }
 
 output "certificate_validation_options" {


### PR DESCRIPTION
this is useful when trying to attach the certificate to a LoadBalancer outside of this module. Waiting for the Certificate to be validated before trying to attach the Certificates simplifies the use of this module