### PR TITLE
avoid error on state mismatches

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,8 @@ locals {
   tld              = element(local.domain_parts, length(local.domain_parts) - 1)
   domain_parts     = var.parent_domain_name == "" ? [var.tld] : split(".", var.parent_domain_name)
   fqdn             = var.domain_name == "" ? format("%s.%s", module.label.id, local.tld) : var.domain_name
-  public_zone_id   = var.enabled ? local.use_public ? join("", aws_route53_zone.public_zone.*.zone_id) : aws_route53_zone.dns_zone.0.zone_id : ""
-  public_ns        = var.enabled ? local.use_public ? flatten(aws_route53_zone.public_zone.*.name_servers) : aws_route53_zone.dns_zone.0.name_servers : []
+  public_zone_id   = var.enabled ? join("", local.use_public ? aws_route53_zone.public_zone.*.zone_id : aws_route53_zone.dns_zone.*.zone_id) : ""
+  public_ns        = var.enabled ? flatten(local.use_public ? aws_route53_zone.public_zone.*.name_servers : aws_route53_zone.dns_zone.*.name_servers) : []
   vpc_ids          = var.vpc_module_state == "" ? var.zone_vpcs : concat(var.zone_vpcs, data.terraform_remote_state.vpc.*.outputs.vpc_id)
   label_order      = contains(local.prod_stages, var.stage) && var.omit_prod_stage ? ["name", "attributes", "namespace"] : ["name", "stage", "attributes", "namespace"]
   tag_overwrites = {


### PR DESCRIPTION
in case the hosted zone is deleted using legacy splat syntax for now
we will need to migrate to newer splat syntax anyway

avoids errors like:
```
Error: Invalid index

  on .terraform/modules/zone/main.tf line 10, in locals:
  10:   public_ns        = var.enabled ? local.use_public ? flatten(aws_route53_zone.public_zone.*.name_servers) : aws_route53_zone.dns_zone.0.name_servers : []
    |----------------
    | aws_route53_zone.dns_zone is empty tuple

The given key does not identify an element in this collection value.